### PR TITLE
fix: uvicorn blocking workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,5 +24,5 @@ jobs:
             git pull origin main
             source /home/ubuntu/fastapi-book-project/venv/bin/activate  
             pip install -r requirements.txt               
+            sudo systemctl restart fastapi
             sudo systemctl restart nginx
-            python3 -m uvicorn main:app 


### PR DESCRIPTION
Calling uvicorn directly does not allow the deploy action to complete, since the workflow never actually ends. 
Now Uvicorn should run in the background without blocking the workflow.
